### PR TITLE
Support for Get Multiple Catalog Albums by UPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Currently, it work in progress, so it can use apis which does not need user toke
 | Get a Catalog Album | :white_check_mark: | [:link:](https://developer.apple.com/documentation/applemusicapi/get_a_catalog_album) | [:octocat:](#) |
 | Get a Catalog Album's Relationship Directly by Name | :white_check_mark: | [:link:](https://developer.apple.com/documentation/applemusicapi/get_a_catalog_album_s_relationship_directly_by_name) | [:octocat:](#) |
 | Get Multiple Catalog Albums | :white_check_mark: | [:link:](https://developer.apple.com/documentation/applemusicapi/get_multiple_catalog_albums) | [:octocat:](#) |
+| Get Multiple Catalog Albums by UPC | :white_check_mark: | [:link:](https://developer.apple.com/documentation/applemusicapi/get_multiple_catalog_albums_by_upc) | [:octocat:](#) |
 | Get a Library Album | :no_entry: | [:link:](https://developer.apple.com/documentation/applemusicapi/get_a_library_album) | |
 | Get a Library Album's Relationship Directly by Name | :no_entry: | [:link:](https://developer.apple.com/documentation/applemusicapi/get_a_library_album_s_relationship_directly_by_name) | |
 | Get Multiple Library Albums | :no_entry: | [:link:](https://developer.apple.com/documentation/applemusicapi/get_multiple_library_albums) | |

--- a/lib/apple_music/album.rb
+++ b/lib/apple_music/album.rb
@@ -13,10 +13,15 @@ module AppleMusic
       end
 
       # e.g. AppleMusic::Album.list(ids: [310730204, 19075891])
+      # e.g. AppleMusic::Album.list(upc: '8717837013241')
       def list(**options)
-        raise ParameterMissing, 'required parameter :ids is missing' unless options[:ids]
-
-        get_collection_by_ids(options.delete(:ids), options)
+        if options[:ids]
+          get_collection_by_ids(options.delete(:ids), **options)
+        elsif options[:upc]
+          get_collection_by_upc(options.delete(:upc), **options)
+        else
+          raise ParameterMissing, 'required parameter :ids or :upc is missing'
+        end
       end
 
       # e.g. AppleMusic::Album.get_collection_by_ids([310730204, 19075891])
@@ -25,6 +30,15 @@ module AppleMusic
         ids = ids.is_a?(Array) ? ids.join(',') : ids
         storefront = Storefront.lookup(options.delete(:storefront))
         response = AppleMusic.get("catalog/#{storefront}/albums", options.merge(ids: ids))
+        Response.new(response.body).data
+      end
+
+      # e.g. AppleMusic::Album.get_collection_by_upc(8717837013241)
+      # https://developer.apple.com/documentation/applemusicapi/get_multiple_catalog_albums_by_upc
+      def get_collection_by_upc(upc, **options)
+        upc = upc.is_a?(Array) ? upc.join(',') : upc
+        storefront = Storefront.lookup(options.delete(:storefront))
+        response = AppleMusic.get("catalog/#{storefront}/albums", options.merge('filter[upc]': upc))
         Response.new(response.body).data
       end
 

--- a/lib/apple_music/album/attributes.rb
+++ b/lib/apple_music/album/attributes.rb
@@ -2,12 +2,12 @@
 
 module AppleMusic
   class Album < Resource
-    # https://developer.apple.com/documentation/applemusicapi/album/attributes
+    # https://developer.apple.com/documentation/applemusicapi/albums/attributes
     class Attributes
       attr_reader :album_name, :artist_name, :artwork, :content_rating,
                   :copyright, :editorial_notes, :genre_names, :is_complete,
                   :is_single, :name, :play_params, :record_label, :release_date,
-                  :track_count, :url, :is_mastered_for_itunes
+                  :track_count, :url, :is_mastered_for_itunes, :upc
 
       def initialize(props = {})
         @album_name = props['albumName'] # required
@@ -30,6 +30,7 @@ module AppleMusic
         @track_count = props['trackCount'] # required
         @url = props['url'] # required
         @is_mastered_for_itunes = props['isMasteredForItunes'] # required
+        @upc = props['upc']
       end
 
       def complete?


### PR DESCRIPTION
- Support for [Get Multiple Catalog Albums by UPC](https://developer.apple.com/documentation/applemusicapi/get_multiple_catalog_albums_by_upc)
- Add upc to Album's Attributes
  - ref. https://developer.apple.com/documentation/applemusicapi/albums/attributes